### PR TITLE
send a proper response from auth service

### DIFF
--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -27,4 +28,7 @@ func HandleAuth(w http.ResponseWriter, r *http.Request) {
 		utils.HandleError(w, err)
 		return
 	}
+
+	w.Header().Set("content-type", "text/plain")
+	fmt.Fprintf(w, "ok")
 }


### PR DESCRIPTION
This change ensures the service sets an explicit content-type on its responses and sends an "ok" message on successful requests.