### PR TITLE
chore: add event streaming test endpoints

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"log"
 	"net/http"
 
@@ -17,7 +18,11 @@ import (
 	"github.com/speakeasy-api/speakeasy-api-test-service/internal/requestbody"
 )
 
+var bindArg = flag.String("b", ":8080", "Bind address")
+
 func main() {
+	flag.Parse()
+
 	r := mux.NewRouter()
 	r.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("pong"))
@@ -40,8 +45,13 @@ func main() {
 	r.HandleFunc("/eventstreams/rich", eventstreams.HandleEventStreamRich).Methods(http.MethodPost)
 	r.HandleFunc("/eventstreams/chat", eventstreams.HandleEventStreamChat).Methods(http.MethodPost)
 
-	log.Println("Listening on :8080")
-	if err := http.ListenAndServe(":8080", r); err != nil {
+	bind := ":8080"
+	if bindArg != nil {
+		bind = *bindArg
+	}
+
+	log.Printf("Listening on %s\n", bind)
+	if err := http.ListenAndServe(bind, r); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/speakeasy-api/speakeasy-api-test-service/internal/acceptHeaders"
 	"github.com/speakeasy-api/speakeasy-api-test-service/internal/errors"
+	"github.com/speakeasy-api/speakeasy-api-test-service/internal/eventstreams"
 	"github.com/speakeasy-api/speakeasy-api-test-service/internal/pagination"
 	"github.com/speakeasy-api/speakeasy-api-test-service/internal/readonlywriteonly"
 	"github.com/speakeasy-api/speakeasy-api-test-service/internal/responseHeaders"
@@ -33,6 +34,11 @@ func main() {
 	r.HandleFunc("/readonlyorwriteonly", readonlywriteonly.HandleReadOrWrite).Methods(http.MethodPost)
 	r.HandleFunc("/readonlyandwriteonly", readonlywriteonly.HandleReadAndWrite).Methods(http.MethodPost)
 	r.HandleFunc("/writeonlyoutput", readonlywriteonly.HandleWriteOnlyOutput).Methods(http.MethodPost)
+	r.HandleFunc("/eventstreams/json", eventstreams.HandleEventStreamJSON).Methods(http.MethodPost)
+	r.HandleFunc("/eventstreams/text", eventstreams.HandleEventStreamText).Methods(http.MethodPost)
+	r.HandleFunc("/eventstreams/multiline", eventstreams.HandleEventStreamMultiLine).Methods(http.MethodPost)
+	r.HandleFunc("/eventstreams/rich", eventstreams.HandleEventStreamRich).Methods(http.MethodPost)
+	r.HandleFunc("/eventstreams/chat", eventstreams.HandleEventStreamChat).Methods(http.MethodPost)
 
 	log.Println("Listening on :8080")
 	if err := http.ListenAndServe(":8080", r); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/speakeasy-api/speakeasy-api-test-service
 
 go 1.19
 
-require github.com/gorilla/mux v1.8.0 // indirect
+require github.com/gorilla/mux v1.8.0

--- a/internal/eventstreams/service.go
+++ b/internal/eventstreams/service.go
@@ -1,0 +1,128 @@
+package eventstreams
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+func pushEvents(rw http.ResponseWriter, events [][]string) {
+	for _, event := range events {
+		for _, line := range event {
+			fmt.Fprintln(rw, line)
+		}
+		fmt.Fprintln(rw, "")
+
+		if f, ok := rw.(http.Flusher); ok {
+			f.Flush()
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func HandleEventStreamJSON(rw http.ResponseWriter, _ *http.Request) {
+	rw.Header().Add("Content-Type", "text/event-stream")
+
+	pushEvents(rw, [][]string{
+		{
+			`data: {"content": "Hello"}`,
+		},
+
+		{
+			`data: {"content": " "}`,
+		},
+
+		{
+			`data: {"content": "world"}`,
+		},
+
+		{
+			`data: {"content": "!"}`,
+		},
+	})
+}
+
+func HandleEventStreamText(rw http.ResponseWriter, _ *http.Request) {
+	rw.Header().Add("Content-Type", "text/event-stream")
+
+	pushEvents(rw, [][]string{
+		{
+			`data: Hello`,
+		},
+
+		{
+			`data:  `,
+		},
+
+		{
+			`data: world`,
+		},
+
+		{
+			`data: !`,
+		},
+	})
+}
+
+func HandleEventStreamMultiLine(rw http.ResponseWriter, _ *http.Request) {
+	rw.Header().Add("Content-Type", "text/event-stream")
+
+	pushEvents(rw, [][]string{
+		{
+			`data: YHOO`,
+			`data: +2`,
+			`data: 10`,
+		},
+	})
+}
+
+func HandleEventStreamRich(rw http.ResponseWriter, _ *http.Request) {
+	rw.Header().Add("Content-Type", "text/event-stream")
+
+	pushEvents(rw, [][]string{
+		{
+			`id: job-1`,
+			`event: completion`,
+			`data: {"completion": "Hello", "stop_reason": null, "model": "jeeves-1"}`,
+		},
+
+		{
+			`event: heartbeat`,
+			`data: ping`,
+			`retry: 3000`,
+		},
+
+		{
+			`id: job-1`,
+			`event: completion`,
+			`data: {"completion": "world!", "stop_reason": "stop_sequence", "model": "jeeves-1"}`,
+		},
+	})
+}
+
+func HandleEventStreamChat(rw http.ResponseWriter, _ *http.Request) {
+	rw.Header().Add("Content-Type", "text/event-stream")
+
+	pushEvents(rw, [][]string{
+		{
+			`data: {"content": "Hello"}`,
+		},
+
+		{
+			`data: {"content": " "}`,
+		},
+
+		{
+			`data: {"content": "world"}`,
+		},
+
+		{
+			`data: {"content": "!"}`,
+		},
+
+		{
+			`data: [DONE]`,
+		},
+	})
+}


### PR DESCRIPTION
This change adds mock endpoints that stream server-sent events. These will support the test suite in openapi-generation.

Also added the ability to run the server using a different bind address. This is helpful when running the project locally outside of docker.