### PR TITLE
feat: add fault injection middleware to the server

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/speakeasy-api/speakeasy-api-test-service/internal/clientcredentials"
 	"github.com/speakeasy-api/speakeasy-api-test-service/internal/errors"
 	"github.com/speakeasy-api/speakeasy-api-test-service/internal/eventstreams"
+	"github.com/speakeasy-api/speakeasy-api-test-service/internal/middleware"
 	"github.com/speakeasy-api/speakeasy-api-test-service/internal/pagination"
 	"github.com/speakeasy-api/speakeasy-api-test-service/internal/readonlywriteonly"
 	"github.com/speakeasy-api/speakeasy-api-test-service/internal/responseHeaders"
@@ -52,13 +53,15 @@ func main() {
 	r.HandleFunc("/clientcredentials/token", clientcredentials.HandleTokenRequest).Methods(http.MethodPost)
 	r.HandleFunc("/clientcredentials/authenticatedrequest", clientcredentials.HandleAuthenticatedRequest).Methods(http.MethodPost)
 
+	handler := middleware.Fault(r)
+
 	bind := ":8080"
 	if bindArg != nil {
 		bind = *bindArg
 	}
 
 	log.Printf("Listening on %s\n", bind)
-	if err := http.ListenAndServe(bind, r); err != nil {
+	if err := http.ListenAndServe(bind, handler); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/speakeasy-api/speakeasy-api-test-service
 
 go 1.22
 
-require github.com/gorilla/mux v1.8.0
+require (
+	github.com/gorilla/mux v1.8.0
+	github.com/lingrino/go-fault v1.0.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/lingrino/go-fault v1.0.2 h1:I7gj2vsxw0wdOwQIX7AZ7kdZRXPX2AgVvRyFXCqSvLA=
+github.com/lingrino/go-fault v1.0.2/go.mod h1:+NkrrGRAoJTcF/OCN9Gvj2ctutYWIYQRV4VS9CI7fmo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/middleware/fault.go
+++ b/internal/middleware/fault.go
@@ -1,0 +1,130 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/lingrino/go-fault"
+)
+
+type FaultSession struct {
+	// RequestCount is the number of requests that have been made on this session.
+	RequestCount int
+	// Exhausted is set to true when all faults on this session have been exercised.
+	Exhausted bool
+	Settings  FaultSettings
+}
+
+type FaultSettings struct {
+	// NOTE: The way these fields are ordered represents their precedence in the
+	// fault chain.
+
+	// DelayMS is the number of milliseconds to delay the request.
+	DelayMS int64 `json:"delay_ms"`
+	// DelayCount is the number of times to delay the request.
+	DelayCount int `json:"delay_count"`
+
+	// RejectCount is the number of times to reject the request without a response.
+	// A value greater than 0 enables this fault injector.
+	RejectCount int `json:"reject_count"`
+
+	// ErrorCount is the number of times to return an error status code.
+	// A value greater than 0 enables this fault injector.
+	//
+	// NOTE: Error injection only takes effect after all rejections have
+	// resolved if both of these injectors are enabled.
+	ErrorCount int `json:"error_count"`
+	// ErrorCode is the status code to return when the error injector is enabled.
+	ErrorCode int `json:"error_code"`
+}
+
+func Fault(h http.Handler) http.Handler {
+	var sessions sync.Map
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqid := r.Header.Get("request-id")
+		if reqid == "" {
+			h.ServeHTTP(w, r)
+			return
+		}
+
+		settinghdr := r.Header.Get("fault-settings")
+		if settinghdr == "" {
+			h.ServeHTTP(w, r)
+			return
+		}
+
+		session := &FaultSession{}
+		asession, found := sessions.Load(reqid)
+		if found {
+			session = asession.(*FaultSession)
+			if session.Exhausted {
+				h.ServeHTTP(w, r)
+				return
+			}
+		}
+
+		var settings FaultSettings
+		err := json.Unmarshal([]byte(settinghdr), &settings)
+		if err != nil {
+			http.Error(w, "Invalid fault settings", http.StatusBadRequest)
+			return
+		}
+
+		reqCount := session.RequestCount
+		session.Settings = settings
+		session.RequestCount++
+		defer func() {
+			sessions.Store(reqid, session)
+		}()
+
+		var faults []fault.Injector
+
+		if settings.DelayMS > 0 && reqCount < settings.DelayCount {
+			inj, err := fault.NewSlowInjector(time.Millisecond * time.Duration(settings.DelayMS))
+			if err != nil {
+				http.Error(w, "Failed to build slow injector", http.StatusInternalServerError)
+				return
+			}
+
+			faults = append(faults, inj)
+		}
+
+		countOffset := 0
+		if settings.RejectCount > 0 && reqCount < settings.RejectCount+countOffset {
+			inj, err := fault.NewRejectInjector()
+			if err != nil {
+				http.Error(w, "Failed to build reject injector", http.StatusInternalServerError)
+				return
+			}
+
+			faults = append(faults, inj)
+		}
+
+		countOffset += settings.RejectCount
+		if settings.ErrorCode > 0 && reqCount < (settings.ErrorCount+countOffset) {
+			inj, err := fault.NewErrorInjector(settings.ErrorCode, fault.WithStatusText("Injected error"))
+			if err != nil {
+				http.Error(w, "Failed to build error injector", http.StatusInternalServerError)
+				return
+			}
+
+			faults = append(faults, inj)
+		}
+
+		if len(faults) == 0 {
+			session.Exhausted = true
+			h.ServeHTTP(w, r)
+			return
+		}
+
+		faultchain, err := fault.NewChainInjector(faults)
+		if err != nil {
+			http.Error(w, "Failed to build fault chain injector", http.StatusInternalServerError)
+		}
+
+		w.Header().Set("Faults-Enabled", "true")
+		faultchain.Handler(h).ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
This change adds a middleware around all routes in the test server that can be used to trigger faults when serving requests. The middleware is only enabled on requests with `Request-ID` AND `Fault-Settings` headers set. The `Fault-Settings` header is a JSON object which is used to configure whether or not to delay responses, reject requests and/or return HTTP error codes.