### PR TITLE
feat: add endpoint with pagination and pagInfo object

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -34,6 +34,7 @@ func main() {
 	r.HandleFunc("/requestbody", requestbody.HandleRequestBody).Methods(http.MethodPost)
 	r.HandleFunc("/vendorjson", responseHeaders.HandleVendorJsonResponseHeaders).Methods(http.MethodGet)
 	r.HandleFunc("/pagination/limitoffset/page", pagination.HandleLimitOffsetPage).Methods(http.MethodGet, http.MethodPut)
+	r.HandleFunc("/pagination/limitoffset/deep_outputs/page", pagination.HandleLimitOffsetDeepOutputsPage).Methods(http.MethodGet, http.MethodPut)
 	r.HandleFunc("/pagination/limitoffset/offset", pagination.HandleLimitOffsetOffset).Methods(http.MethodGet, http.MethodPut)
 	r.HandleFunc("/pagination/cursor", pagination.HandleCursor).Methods(http.MethodGet, http.MethodPut)
 	r.HandleFunc("/pagination/url", pagination.HandleURL).Methods(http.MethodGet)


### PR DESCRIPTION
This endpoint powers test cases that have to use JSONPath to drill deeper than one to get at pagination outputs.