### PR TITLE
feat: add sse chat endpoint with arbitrary chunks

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -51,6 +51,7 @@ func main() {
 	r.HandleFunc("/eventstreams/multiline", eventstreams.HandleEventStreamMultiLine).Methods(http.MethodPost)
 	r.HandleFunc("/eventstreams/rich", eventstreams.HandleEventStreamRich).Methods(http.MethodPost)
 	r.HandleFunc("/eventstreams/chat", eventstreams.HandleEventStreamChat).Methods(http.MethodPost)
+	r.HandleFunc("/eventstreams/chat-chunked", eventstreams.HandleEventStreamChat).Methods(http.MethodPost)
 	r.HandleFunc("/eventstreams/differentdataschemas", eventstreams.HandleEventStreamDifferentDataSchemas).Methods(http.MethodPost)
 	r.HandleFunc("/clientcredentials/token", clientcredentials.HandleTokenRequest).Methods(http.MethodPost)
 	r.HandleFunc("/clientcredentials/authenticatedrequest", clientcredentials.HandleAuthenticatedRequest).Methods(http.MethodPost)

--- a/internal/eventstreams/service.go
+++ b/internal/eventstreams/service.go
@@ -6,6 +6,18 @@ import (
 	"time"
 )
 
+func pushChunks(rw http.ResponseWriter, chunks []string) {
+	for _, chunk := range chunks {
+		fmt.Fprintln(rw, chunk)
+
+		if f, ok := rw.(http.Flusher); ok {
+			f.Flush()
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
 func pushEvents(rw http.ResponseWriter, events [][]string) {
 	for _, event := range events {
 		for _, line := range event {
@@ -124,6 +136,18 @@ func HandleEventStreamChat(rw http.ResponseWriter, _ *http.Request) {
 		{
 			`data: [DONE]`,
 		},
+	})
+}
+
+func HandleEventStreamChatChunked(rw http.ResponseWriter, _ *http.Request) {
+	rw.Header().Add("Content-Type", "text/event-stream")
+
+	pushChunks(rw, []string{
+		"data: {\"content\": ",
+		"\"Hello\"}\n\ndata: {\"content\": \" \"}",
+		"data: {\"content\": \"world\"}",
+		"data: {\"content\": \"!\"}\n\ndata: [DONE]\n",
+		"\ndata: {\"content\": \"Post sentinel data\"}\n\n",
 	})
 }
 


### PR DESCRIPTION
This change adds a new endpoint which streams server-sent events in arbitrarily sized chunks to exercise the buffering and scanning functionality in SDKs.