### PR TITLE
feat: Add HTTP method testing endpoints

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/speakeasy-api/speakeasy-api-test-service/internal/clientcredentials"
 	"github.com/speakeasy-api/speakeasy-api-test-service/internal/errors"
 	"github.com/speakeasy-api/speakeasy-api-test-service/internal/eventstreams"
+	"github.com/speakeasy-api/speakeasy-api-test-service/internal/method"
 	"github.com/speakeasy-api/speakeasy-api-test-service/internal/middleware"
 	"github.com/speakeasy-api/speakeasy-api-test-service/internal/pagination"
 	"github.com/speakeasy-api/speakeasy-api-test-service/internal/readonlywriteonly"
@@ -58,6 +59,14 @@ func main() {
 	r.HandleFunc("/clientcredentials/alt/token", clientcredentials.HandleTokenRequest).Methods(http.MethodPost)
 	r.HandleFunc("/clientcredentials/alt/authenticatedrequest", clientcredentials.HandleAuthenticatedRequest).Methods(http.MethodPost)
 	r.HandleFunc("/reflect", reflect.HandleReflect).Methods(http.MethodPost)
+	r.HandleFunc("/method/delete", method.HandleDelete).Methods(http.MethodDelete)
+	r.HandleFunc("/method/get", method.HandleGet).Methods(http.MethodGet)
+	r.HandleFunc("/method/head", method.HandleHead).Methods(http.MethodHead)
+	r.HandleFunc("/method/options", method.HandleOptions).Methods(http.MethodOptions)
+	r.HandleFunc("/method/patch", method.HandlePatch).Methods(http.MethodPatch)
+	r.HandleFunc("/method/post", method.HandlePost).Methods(http.MethodPost)
+	r.HandleFunc("/method/put", method.HandlePut).Methods(http.MethodPut)
+	r.HandleFunc("/method/trace", method.HandleTrace).Methods(http.MethodTrace)
 
 	handler := middleware.Fault(r)
 

--- a/internal/method/service.go
+++ b/internal/method/service.go
@@ -1,0 +1,218 @@
+package method
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/speakeasy-api/speakeasy-api-test-service/internal/utils"
+)
+
+func HandleDelete(w http.ResponseWriter, r *http.Request) {
+	type RequestBody struct {
+		ID string `json:"id"`
+	}
+	type ResponseBody struct {
+		Status string `json:"status"`
+	}
+
+	var requestBody RequestBody
+
+	body, err := io.ReadAll(r.Body)
+
+	if err != nil {
+		utils.HandleError(w, err)
+		return
+	}
+
+	if err := json.Unmarshal(body, &requestBody); err != nil {
+		utils.HandleError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	responseBody := ResponseBody{
+		Status: "OK",
+	}
+
+	if err := json.NewEncoder(w).Encode(responseBody); err != nil {
+		utils.HandleError(w, err)
+		return
+	}
+}
+
+func HandleGet(w http.ResponseWriter, r *http.Request) {
+	type RequestBody struct {
+		ID string `json:"id"`
+	}
+	type ResponseBody struct {
+		Status string `json:"status"`
+	}
+
+	var requestBody RequestBody
+
+	body, err := io.ReadAll(r.Body)
+
+	if err != nil {
+		utils.HandleError(w, err)
+		return
+	}
+
+	if err := json.Unmarshal(body, &requestBody); err != nil {
+		utils.HandleError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	responseBody := ResponseBody{
+		Status: "OK",
+	}
+
+	if err := json.NewEncoder(w).Encode(responseBody); err != nil {
+		utils.HandleError(w, err)
+		return
+	}
+}
+
+func HandleHead(w http.ResponseWriter, r *http.Request) {
+	type RequestBody struct {
+		ID string `json:"id"`
+	}
+
+	var requestBody RequestBody
+
+	body, err := io.ReadAll(r.Body)
+
+	if err != nil {
+		utils.HandleError(w, err)
+		return
+	}
+
+	if err := json.Unmarshal(body, &requestBody); err != nil {
+		utils.HandleError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+}
+
+func HandleOptions(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Allow", "OPTIONS")
+	w.WriteHeader(http.StatusOK)
+}
+
+func HandlePatch(w http.ResponseWriter, r *http.Request) {
+	type RequestBody struct {
+		ID string `json:"id"`
+	}
+	type ResponseBody struct {
+		Status string `json:"status"`
+	}
+
+	var requestBody RequestBody
+
+	body, err := io.ReadAll(r.Body)
+
+	if err != nil {
+		utils.HandleError(w, err)
+		return
+	}
+
+	if err := json.Unmarshal(body, &requestBody); err != nil {
+		utils.HandleError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	responseBody := ResponseBody{
+		Status: "OK",
+	}
+
+	if err := json.NewEncoder(w).Encode(responseBody); err != nil {
+		utils.HandleError(w, err)
+		return
+	}
+}
+
+func HandlePost(w http.ResponseWriter, r *http.Request) {
+	type RequestBody struct {
+		ID string `json:"id"`
+	}
+	type ResponseBody struct {
+		Status string `json:"status"`
+	}
+
+	var requestBody RequestBody
+
+	body, err := io.ReadAll(r.Body)
+
+	if err != nil {
+		utils.HandleError(w, err)
+		return
+	}
+
+	if err := json.Unmarshal(body, &requestBody); err != nil {
+		utils.HandleError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	responseBody := ResponseBody{
+		Status: "OK",
+	}
+
+	if err := json.NewEncoder(w).Encode(responseBody); err != nil {
+		utils.HandleError(w, err)
+		return
+	}
+}
+
+func HandlePut(w http.ResponseWriter, r *http.Request) {
+	type RequestBody struct {
+		ID string `json:"id"`
+	}
+	type ResponseBody struct {
+		Status string `json:"status"`
+	}
+
+	var requestBody RequestBody
+
+	body, err := io.ReadAll(r.Body)
+
+	if err != nil {
+		utils.HandleError(w, err)
+		return
+	}
+
+	if err := json.Unmarshal(body, &requestBody); err != nil {
+		utils.HandleError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	responseBody := ResponseBody{
+		Status: "OK",
+	}
+
+	if err := json.NewEncoder(w).Encode(responseBody); err != nil {
+		utils.HandleError(w, err)
+		return
+	}
+}
+
+func HandleTrace(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "message/http")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("TRACE /method/trace HTTP/1.1\r\nHost: example.com\r\n"))
+}


### PR DESCRIPTION
Adds the following endpoints for generator testing of all OAS HTTP methods:

* `DELETE /method/delete`
* `GET /method/get`
* `HEAD /method/head`
* `OPTIONS /method/options`
* `PATCH /method/patch`
* `POST /method/post`
* `PUT /method/put`
* `TRACE /method/trace`

Eventually, this should be handled by the generated mock server, but this introduces testing coverage immediately.