### PR TITLE
fix: Remove GET/HEAD method request body handling

### DIFF
--- a/internal/method/service.go
+++ b/internal/method/service.go
@@ -44,25 +44,8 @@ func HandleDelete(w http.ResponseWriter, r *http.Request) {
 }
 
 func HandleGet(w http.ResponseWriter, r *http.Request) {
-	type RequestBody struct {
-		ID string `json:"id"`
-	}
 	type ResponseBody struct {
 		Status string `json:"status"`
-	}
-
-	var requestBody RequestBody
-
-	body, err := io.ReadAll(r.Body)
-
-	if err != nil {
-		utils.HandleError(w, err)
-		return
-	}
-
-	if err := json.Unmarshal(body, &requestBody); err != nil {
-		utils.HandleError(w, err)
-		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -79,24 +62,6 @@ func HandleGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func HandleHead(w http.ResponseWriter, r *http.Request) {
-	type RequestBody struct {
-		ID string `json:"id"`
-	}
-
-	var requestBody RequestBody
-
-	body, err := io.ReadAll(r.Body)
-
-	if err != nil {
-		utils.HandleError(w, err)
-		return
-	}
-
-	if err := json.Unmarshal(body, &requestBody); err != nil {
-		utils.HandleError(w, err)
-		return
-	}
-
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
Reference: https://github.com/whatwg/fetch/issues/551

Certain interpretations and implementations of the IETF RFC do not support GET/HEAD HTTP method request body content. The request body checking is extraneous for the purpose of this testing, which is only intended for just the HTTP methods themselves, so just removing it.