### PR TITLE
chore: add teapot middleware

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -70,6 +70,7 @@ func main() {
 	r.HandleFunc("/method/trace", method.HandleTrace).Methods(http.MethodTrace)
 
 	handler := middleware.Fault(r)
+	handler = middleware.Teapot(handler)
 
 	bind := ":8080"
 	if bindArg != nil {

--- a/internal/middleware/teapot.go
+++ b/internal/middleware/teapot.go
@@ -1,0 +1,25 @@
+package middleware
+
+import "net/http"
+
+func Teapot(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		format := r.Header.Get("x-teapot")
+		if format == "" {
+			h.ServeHTTP(w, r)
+			return
+		}
+
+		if format == "json" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTeapot)
+			w.Write([]byte(`{"message": "I'm a teapot"}`))
+			return
+		} else {
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusTeapot)
+			w.Write([]byte("I'm a teapot\n"))
+			return
+		}
+	})
+}


### PR DESCRIPTION
This change adds a new HTTP middleware to that intercepts requests with an `x-teapot` header and responds with a 418 status code and a message in json or text format depending on the value of the header.

This middleware provides a simple mechanism to trigger error responses.