### PR TITLE
feat: add oauth2 and ecommerce test apis

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/speakeasy-api/speakeasy-api-test-service
 
-go 1.22
+go 1.23
 
 require (
+	github.com/brianvoe/gofakeit/v7 v7.0.4
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/gorilla/mux v1.8.0
 	github.com/lingrino/go-fault v1.0.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
+github.com/brianvoe/gofakeit/v7 v7.0.4 h1:Mkxwz9jYg8Ad8NvT9HA27pCMZGFQo08MK6jD0QTKEww=
+github.com/brianvoe/gofakeit/v7 v7.0.4/go.mod h1:QXuPeBw164PJCzCUZVmgpgHJ3Llj49jSLVkKPMtxtxA=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/lingrino/go-fault v1.0.2 h1:I7gj2vsxw0wdOwQIX7AZ7kdZRXPX2AgVvRyFXCqSvLA=

--- a/internal/auth/oauth2.go
+++ b/internal/auth/oauth2.go
@@ -1,0 +1,312 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/brianvoe/gofakeit/v7"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	oauth2JWTSigningSecret = "fancy-jwt-signing-secret"
+)
+
+type OAuth2ErrorCode string
+
+const (
+	ErrCodeInvalidRequest       OAuth2ErrorCode = "invalid_request"
+	ErrCodeInvalidClient        OAuth2ErrorCode = "invalid_client"
+	ErrCodeInvalidGrant         OAuth2ErrorCode = "invalid_grant"
+	ErrCodeUnauthorizedClient   OAuth2ErrorCode = "unauthorized_client"
+	ErrCodeUnsupportedGrantType OAuth2ErrorCode = "unsupported_grant_type"
+	ErrCodeInvalidScope         OAuth2ErrorCode = "invalid_scope"
+)
+
+func (e OAuth2ErrorCode) Error() string {
+	return string(e)
+}
+
+type oauth2Error struct {
+	Code    OAuth2ErrorCode `json:"error"`
+	Message string          `json:"error_description,omitempty"`
+}
+
+func SendOAuth2Error(w http.ResponseWriter, code OAuth2ErrorCode, description string) {
+	payload := oauth2Error{
+		Code:    code,
+		Message: description,
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	if err := enc.Encode(payload); err != nil {
+		log.Println(err)
+
+		http.Error(w, `{"error": "failed to encode response"}`, http.StatusInternalServerError)
+		return
+	}
+}
+
+type TokenForm struct {
+	GrantType    string `json:"grant_type"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	Username     string `json:"username"`
+	Password     string `json:"password"`
+	Code         string `json:"code"`
+	RedirectURI  string `json:"redirect_uri"`
+	RefreshToken string `json:"refresh_token"`
+	Scope        string `json:"scope"`
+}
+
+type OAuth2TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+}
+
+func HandleOAuth2(w http.ResponseWriter, r *http.Request) {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+
+	w.Header().Set("Content-Type", "application/json")
+
+	defer r.Body.Close()
+
+	if err := r.ParseForm(); err != nil {
+		log.Println(err)
+		SendOAuth2Error(w, ErrCodeInvalidRequest, "cannot parse url-encoded request body")
+		return
+	}
+
+	form := TokenForm{
+		GrantType:    r.PostForm.Get("grant_type"),
+		ClientID:     r.PostForm.Get("client_id"),
+		ClientSecret: r.PostForm.Get("client_secret"),
+		Username:     r.PostForm.Get("username"),
+		Password:     r.PostForm.Get("password"),
+		Code:         r.PostForm.Get("code"),
+		RedirectURI:  r.PostForm.Get("redirect_uri"),
+		RefreshToken: r.PostForm.Get("refresh_token"),
+		Scope:        r.PostForm.Get("scope"),
+	}
+
+	switch form.GrantType {
+	case "client_credentials":
+		if form.ClientID == "" || form.ClientSecret == "" {
+			SendOAuth2Error(w, ErrCodeInvalidRequest, "missing client credentials")
+			return
+		}
+
+		if !validateClientCredentials(r, form) {
+			SendOAuth2Error(w, ErrCodeInvalidClient, "invalid client id or secret")
+			return
+		}
+	case "password":
+		if form.ClientID == "" || form.ClientSecret == "" || form.Username == "" || form.Password == "" {
+			SendOAuth2Error(w, ErrCodeInvalidRequest, "missing resource owner password credentials")
+			return
+		}
+		if !validateClientCredentials(r, form) {
+			SendOAuth2Error(w, ErrCodeInvalidClient, "invalid client id or secret")
+			return
+		}
+		if form.Username != "testuser" || form.Password != "testpassword" {
+			SendOAuth2Error(w, ErrCodeInvalidGrant, "invalid username or password")
+			return
+		}
+	case "authorization_code":
+		if form.ClientID == "" || form.Code == "" {
+			SendOAuth2Error(w, ErrCodeInvalidRequest, "missing authorization code credentials")
+			return
+		}
+		if form.ClientID != "beezy" {
+			SendOAuth2Error(w, ErrCodeInvalidClient, "invalid client id")
+			return
+		}
+		if form.Code != "secret-auth-code" {
+			SendOAuth2Error(w, ErrCodeInvalidGrant, "")
+			return
+		}
+	case "refresh_token":
+		if form.RefreshToken == "" {
+			SendOAuth2Error(w, ErrCodeInvalidRequest, "missing refresh token")
+			return
+		}
+
+		if !validateClientCredentials(r, form) {
+			SendOAuth2Error(w, ErrCodeInvalidGrant, "invalid client id or secret")
+			return
+		}
+
+		rt, err := ParseToken(form.RefreshToken)
+		if err != nil {
+			SendOAuth2Error(w, ErrCodeInvalidRequest, "invalid refresh token")
+			return
+		}
+		if IsTokenExpired(rt) {
+			SendOAuth2Error(w, ErrCodeInvalidGrant, "refresh token has expired")
+			return
+		}
+	default:
+		SendOAuth2Error(w, ErrCodeUnsupportedGrantType, "unsupported grant type")
+		return
+	}
+
+	now := time.Now()
+	expires := now.Add(time.Hour)
+
+	accessTokenID := gofakeit.UUID()
+	accessTokenClaims := jwt.MapClaims{
+		"exp":       float64(expires.Unix()),
+		"id":        accessTokenID,
+		"grantType": form.GrantType,
+		"clientID":  form.ClientID,
+		"username":  form.Username,
+		"scope":     form.Scope,
+	}
+	accessToken := jwt.NewWithClaims(jwt.SigningMethodHS256, accessTokenClaims)
+	signedAccessToken, err := accessToken.SignedString([]byte(oauth2JWTSigningSecret))
+	if err != nil {
+		log.Println(err)
+		SendOAuth2Error(w, ErrCodeInvalidRequest, err.Error())
+		return
+	}
+
+	refreshTokenClaims := jwt.MapClaims{
+		"exp":       float64(now.Add(60 * 24 * time.Hour).Unix()),
+		"id":        gofakeit.UUID(),
+		"sub":       accessTokenID,
+		"grantType": "refresh_token",
+		"clientID":  form.ClientID,
+		"username":  form.Username,
+		"scope":     form.Scope,
+	}
+	refreshToken := jwt.NewWithClaims(jwt.SigningMethodHS256, refreshTokenClaims)
+	signedRefreshToken, err := refreshToken.SignedString([]byte(oauth2JWTSigningSecret))
+	if err != nil {
+		log.Println(err)
+		http.Error(w, `{"error": "failed to sign refresh token"}`, http.StatusInternalServerError)
+		return
+	}
+
+	res := OAuth2TokenResponse{
+		AccessToken:  signedAccessToken,
+		RefreshToken: signedRefreshToken,
+		TokenType:    "Bearer",
+		ExpiresIn:    max(int(expires.Sub(now).Seconds()), 0),
+	}
+
+	RegisterToken(accessTokenClaims)
+	RegisterToken(refreshTokenClaims)
+
+	if err := enc.Encode(res); err != nil {
+		http.Error(w, `{"error": "failed to encode response"}`, http.StatusInternalServerError)
+		return
+	}
+}
+
+func validateClientCredentials(r *http.Request, form TokenForm) bool {
+	clientID := form.ClientID
+	clientSecret := form.ClientSecret
+	if clientID == "" && clientSecret == "" {
+		clientID, clientSecret, _ = r.BasicAuth()
+	}
+
+	return clientID == "beezy" && clientSecret == "super-secret"
+}
+
+var tokenDB sync.Map
+var tokenDBLastAccess atomic.Value
+
+func RegisterToken(tokenClaims jwt.MapClaims) {
+	tokenDBLastAccess.Store(time.Now())
+
+	tokenID := tokenClaims["id"].(string)
+	expiry, err := tokenClaims.GetExpirationTime()
+	if err != nil {
+		panic(err)
+	}
+	tokenDB.Store(tokenID, expiry.Time)
+}
+
+func RefreshToken(refreshClaims jwt.MapClaims) {
+	tokenDBLastAccess.Store(time.Now())
+
+	tokenID := refreshClaims["sub"].(string)
+	expiry := time.Now().Add(time.Hour)
+	tokenDB.Store(tokenID, expiry)
+}
+
+func IsTokenExpired(tokenClaims jwt.MapClaims) bool {
+	tokenDBLastAccess.Store(time.Now())
+
+	tokenID := tokenClaims["id"].(string)
+	expiryClaim, err := tokenClaims.GetExpirationTime()
+	if err != nil {
+		panic(err)
+	}
+
+	exp, found := tokenDB.Load(tokenID)
+	if !found {
+		RegisterToken(tokenClaims)
+		exp = expiryClaim.Time
+	}
+
+	expiry := exp.(time.Time)
+
+	return expiry.Before(time.Now())
+}
+
+func StartTokenDBCompaction(ctx context.Context) {
+	ticker := time.NewTicker(time.Minute)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			lastAccess, ok := tokenDBLastAccess.Load().(time.Time)
+			now := time.Now()
+			if !ok {
+				lastAccess = now
+			}
+
+			delta := now.Sub(lastAccess)
+			if delta > 5*time.Minute {
+				tokenDB.Clear()
+			}
+		}
+	}
+}
+
+func ParseToken(encodedToken string) (jwt.MapClaims, error) {
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation(), jwt.WithValidMethods([]string{"HS256"}))
+	token, err := parser.Parse(encodedToken, func(token *jwt.Token) (any, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+
+		return []byte(oauth2JWTSigningSecret), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, fmt.Errorf("invalid access token string")
+	}
+
+	return claims, nil
+}

--- a/internal/ecommerce/models.go
+++ b/internal/ecommerce/models.go
@@ -1,0 +1,39 @@
+package ecommerce
+
+import "time"
+
+type Product struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	Price       float64   `json:"price"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}
+
+type ProductList struct {
+	NextCursor *string    `json:"nextCursor"`
+	Products   []*Product `json:"products"`
+}
+
+type NewProductForm struct {
+	Name        string  `json:"name"`
+	Description string  `json:"description"`
+	Price       float64 `json:"price"`
+}
+
+type ProductForm struct {
+	Name        string  `json:"name"`
+	Description string  `json:"description"`
+	Price       float64 `json:"price"`
+}
+
+type ProductInventoryUpdateForm struct {
+	QuantityDelta int `json:"quantityDelta"`
+}
+
+type ProductInventoryStatus struct {
+	ProductID string    `json:"productId"`
+	Quantity  int       `json:"quantity"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}

--- a/internal/ecommerce/service.go
+++ b/internal/ecommerce/service.go
@@ -1,0 +1,249 @@
+package ecommerce
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/brianvoe/gofakeit/v7"
+	"github.com/gorilla/mux"
+	"github.com/speakeasy-api/speakeasy-api-test-service/internal/middleware"
+)
+
+func Ptr[T any](t T) *T {
+	return &t
+}
+
+func HandleListProducts(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+
+	scopes, scopesFound := middleware.OAuth2Scopes(r)
+	if !scopesFound || !scopes.Has([]string{"products:read"}) {
+		http.Error(rw, `{"error": "insufficient scopes"}`, http.StatusForbidden)
+		return
+	}
+
+	cursorQ := r.URL.Query().Get("cursor")
+	if cursorQ == "" {
+		cursorQ = "0"
+	}
+
+	cursor, err := strconv.ParseUint(string(cursorQ), 10, 64)
+	if err != nil {
+		http.Error(rw, `{"error": "cursor not a uint64"}`, http.StatusBadRequest)
+		return
+	}
+
+	if cursor%10 != 0 {
+		http.Error(rw, `{"error": "cursor not a multiple of 10"}`, http.StatusBadRequest)
+		return
+	}
+
+	enc := json.NewEncoder(rw)
+	enc.SetIndent("", "  ")
+
+	if cursor > 30 {
+		err := enc.Encode(ProductList{Products: []*Product{}})
+		if err != nil {
+			http.Error(rw, `{"error": "could not encode response"}`, http.StatusInternalServerError)
+		}
+		return
+	}
+
+	next := cursor + 10
+	var nextCursorBody *string
+	if next <= 30 {
+		nextCursorBody = Ptr(fmt.Sprintf("%d", next))
+	}
+
+	// Seed cannot be 0 otherwise faker picks a random one
+	faker := gofakeit.New(cursor + 1)
+
+	products := make([]*Product, 10)
+	for i := 0; i < 10; i++ {
+		p := faker.Product()
+
+		created := faker.DateRange(
+			time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+		).Truncate(24 * time.Hour)
+
+		updated := faker.DateRange(
+			created,
+			time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+		).Truncate(24 * time.Hour)
+
+		products[i] = &Product{
+			ID:        p.UPC,
+			Name:      p.Name,
+			Price:     p.Price,
+			CreatedAt: created,
+			UpdatedAt: updated,
+		}
+	}
+
+	err = enc.Encode(ProductList{
+		NextCursor: nextCursorBody,
+		Products:   products,
+	})
+	if err != nil {
+		http.Error(rw, `{"error": "could not encode response"}`, http.StatusInternalServerError)
+	}
+}
+
+func HandleCreateProduct(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+
+	scopes, scopesFound := middleware.OAuth2Scopes(r)
+	if !scopesFound || !scopes.Has([]string{"products:create"}) {
+		http.Error(rw, `{"error": "insufficient scopes"}`, http.StatusForbidden)
+		return
+	}
+
+	enc := json.NewEncoder(rw)
+	enc.SetIndent("", "  ")
+
+	defer r.Body.Close()
+	var p NewProductForm
+	err := json.NewDecoder(r.Body).Decode(&p)
+	if err != nil {
+		http.Error(rw, `{"error": "could not decode request"}`, http.StatusBadRequest)
+		return
+	}
+
+	faker := gofakeit.New(0)
+
+	now := time.Now().Truncate(24 * time.Second)
+	if err := enc.Encode(Product{
+		ID:          faker.ProductUPC(),
+		Name:        p.Name,
+		Price:       p.Price,
+		Description: p.Description,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}); err != nil {
+		http.Error(rw, `{"error": "could not encode response"}`, http.StatusInternalServerError)
+	}
+}
+
+func HandleFetchProduct(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+
+	scopes, scopesFound := middleware.OAuth2Scopes(r)
+	if !scopesFound || !scopes.Has([]string{"products:read"}) {
+		http.Error(rw, `{"error": "insufficient scopes"}`, http.StatusForbidden)
+		return
+	}
+
+	enc := json.NewEncoder(rw)
+	enc.SetIndent("", "  ")
+
+	vars := mux.Vars(r)
+	rawID, ok := vars["id"]
+	if !ok {
+		http.Error(rw, `{"error": "{id} is required"}`, http.StatusBadRequest)
+		return
+	}
+
+	productID, err := strconv.ParseUint(rawID, 10, 64)
+	if err != nil {
+		http.Error(rw, `{"error": "{id} must a uint64"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Seed cannot be 0 otherwise faker picks a random one
+	faker := gofakeit.New(productID + 1)
+	p := faker.Product()
+	created := faker.DateRange(
+		time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+	).Truncate(24 * time.Hour)
+	updated := faker.DateRange(
+		created,
+		time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+	).Truncate(24 * time.Hour)
+
+	if err := enc.Encode(Product{
+		ID:        rawID,
+		Name:      p.Name,
+		Price:     p.Price,
+		CreatedAt: created,
+		UpdatedAt: updated,
+	}); err != nil {
+		http.Error(rw, `{"error": "could not encode response"}`, http.StatusInternalServerError)
+	}
+}
+
+func HandleDeleteProduct(rw http.ResponseWriter, r *http.Request) {
+	scopes, scopesFound := middleware.OAuth2Scopes(r)
+	if !scopesFound || !scopes.Has([]string{"products:delete"}) {
+		rw.Header().Set("Content-Type", "application/json")
+		http.Error(rw, `{"error": "insufficient scopes"}`, http.StatusForbidden)
+		return
+	}
+
+	vars := mux.Vars(r)
+	rawID, ok := vars["id"]
+	if !ok {
+		http.Error(rw, `{"error": "{id} is required"}`, http.StatusBadRequest)
+		return
+	}
+
+	_, err := strconv.ParseUint(rawID, 10, 64)
+	if err != nil {
+		http.Error(rw, `{"error": "{id} must a uint64"}`, http.StatusBadRequest)
+		return
+	}
+
+	rw.WriteHeader(http.StatusNoContent)
+}
+
+func HandleUpdateProductStock(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+
+	scopes, scopesFound := middleware.OAuth2Scopes(r)
+	if !scopesFound || !scopes.Has([]string{"admin"}) {
+		http.Error(rw, `{"error": "insufficient scopes"}`, http.StatusForbidden)
+		return
+	}
+
+	enc := json.NewEncoder(rw)
+	enc.SetIndent("", "  ")
+
+	vars := mux.Vars(r)
+	rawID, ok := vars["id"]
+	if !ok {
+		http.Error(rw, `{"error": "{id} is required"}`, http.StatusBadRequest)
+		return
+	}
+
+	productID, err := strconv.ParseUint(rawID, 10, 64)
+	if err != nil {
+		http.Error(rw, `{"error": "{id} must a uint64"}`, http.StatusBadRequest)
+		return
+	}
+
+	defer r.Body.Close()
+
+	var form ProductInventoryUpdateForm
+	err = json.NewDecoder(r.Body).Decode(&form)
+	if err != nil {
+		http.Error(rw, `{"error": "could not decode request"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Seed cannot be 0 otherwise faker picks a random one
+	faker := gofakeit.New(productID + 1)
+
+	now := time.Now().Truncate(24 * time.Second)
+	if err := enc.Encode(ProductInventoryStatus{
+		ProductID: rawID,
+		Quantity:  faker.IntRange(int(math.Abs(float64(form.QuantityDelta))), 100) + form.QuantityDelta,
+		UpdatedAt: now,
+	}); err != nil {
+		http.Error(rw, `{"error": "could not encode response"}`, http.StatusInternalServerError)
+	}
+}

--- a/internal/middleware/oauth2.go
+++ b/internal/middleware/oauth2.go
@@ -1,0 +1,88 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/speakeasy-api/speakeasy-api-test-service/internal/auth"
+)
+
+type oauth2CtxKey string
+
+var oauth2ClaimsKey oauth2CtxKey = "oauth2Claims"
+
+func OAuth2(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		authhdr := r.Header.Get("Authorization")
+		if !strings.HasPrefix(authhdr, "Bearer ") {
+			auth.SendOAuth2Error(w, auth.ErrCodeInvalidRequest, "missing bearer token")
+			return
+		}
+
+		claims, err := auth.ParseToken(authhdr[7:])
+		if err != nil {
+			auth.SendOAuth2Error(w, auth.ErrCodeInvalidRequest, err.Error())
+			return
+		}
+
+		if auth.IsTokenExpired(claims) {
+			auth.SendOAuth2Error(w, auth.ErrCodeInvalidRequest, "token has expired")
+			return
+		}
+
+		if claims["grantType"].(string) == "refresh_token" {
+			auth.SendOAuth2Error(w, auth.ErrCodeInvalidRequest, "cannot use refresh token as access token")
+			return
+		}
+
+		w.Header().Set("x-oauth2", "pass")
+		ctx = context.WithValue(ctx, oauth2ClaimsKey, claims)
+		h.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func OAuth2Scopes(r *http.Request) (Scopes, bool) {
+	v := r.Context().Value(oauth2ClaimsKey)
+	if v == nil {
+		return nil, false
+	}
+
+	claims, ok := v.(jwt.MapClaims)
+	if !ok {
+		return nil, false
+	}
+
+	rawscopes, ok := claims["scope"].(string)
+	if !ok {
+		return nil, false
+	}
+
+	elements := strings.Split(rawscopes, " ")
+	var scopes Scopes
+	for _, scope := range elements {
+		scopes = append(scopes, scope)
+	}
+
+	return scopes, true
+}
+
+type Scopes []string
+
+func (s Scopes) Has(requiredScopes []string) bool {
+	if len(s) < len(requiredScopes) {
+		return false
+	}
+
+	for _, required := range requiredScopes {
+		if !slices.Contains(s, required) {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
## OAuth2

This change adds a new OAuth2 middleware and token endpoint that can be used to enforce OAuth2 on any test endpoints. Test code can opt into OAuth2 enforcement by setting the `x-require-oauth2: 1` header on any SDK methods. This is usually done with a custom http client, per-method custom headers or a SDK-wide hook depending on the language and test.

The following OAuth2 flows are supported:

- Client Credentials
- Authorization Code
- Resource Owner Password Credentials
- Refresh Token

When requesting an access token against `POST /oauth2/token`, the following credentials are expected based on the flow used:

- Client ID: `beezy`
- Client Secret: `super-secret`
- Username: `testuser`
- Password: `testpassword`
- Code: `secret-auth-code`
- Refresh Token: `secret-refresh-token`

Test code can look for the `x-oauth2: pass` header to determine if the test service detected and validated OAuth2 access tokens in the response of any non-auth endpoints

## E-commerce API

This is a new set of test APIs that are inspired by real world e-commerce APIs. These APIs can enforce OAuth2 scopes if incoming requests have passed the OAuth2 middleware.