### PR TITLE
fix: return 401 for expired oauth2 tokens

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -30,6 +30,7 @@ func main() {
 	flag.Parse()
 
 	r := mux.NewRouter()
+	r.HandleFunc("/oauth2/token", auth.HandleOAuth2InspectToken).Methods(http.MethodGet)
 	r.HandleFunc("/oauth2/token", auth.HandleOAuth2).Methods(http.MethodPost)
 	r.HandleFunc("/auth", auth.HandleAuth).Methods(http.MethodPost)
 	r.HandleFunc("/auth/customsecurity/{customSchemeType}", auth.HandleCustomAuth).Methods(http.MethodGet)

--- a/internal/middleware/oauth2.go
+++ b/internal/middleware/oauth2.go
@@ -31,7 +31,8 @@ func OAuth2(h http.Handler) http.Handler {
 		}
 
 		if auth.IsTokenExpired(claims) {
-			auth.SendOAuth2Error(w, auth.ErrCodeInvalidRequest, "token has expired")
+			w.Header().Set("Content-Type", "application/json")
+			http.Error(w, `{"error": "token has expired"}`, http.StatusUnauthorized)
 			return
 		}
 


### PR DESCRIPTION
This change updates the OAuth2 middleware to return a 401 Unauthorized response when a token is expired. The previous behavior of returning 400 was non-compliant. We've also added endpoints to introspect access tokens.