### PR TITLE
feat: add sse flat response endpoints

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -75,7 +75,6 @@ func main() {
 	r.HandleFunc("/method/post", method.HandlePost).Methods(http.MethodPost)
 	r.HandleFunc("/method/put", method.HandlePut).Methods(http.MethodPut)
 	r.HandleFunc("/method/trace", method.HandleTrace).Methods(http.MethodTrace)
-	
 	oauth2router := r.NewRoute().Subrouter()
 	oauth2router.Use(middleware.OAuth2)
 	oauth2router.HandleFunc("/ecommerce/products", ecommerce.HandleListProducts).Methods(http.MethodGet)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -60,6 +60,7 @@ func main() {
 	r.HandleFunc("/eventstreams/chat", eventstreams.HandleEventStreamChat).Methods(http.MethodPost)
 	r.HandleFunc("/eventstreams/chat-chunked", eventstreams.HandleEventStreamChat).Methods(http.MethodPost)
 	r.HandleFunc("/eventstreams/differentdataschemas", eventstreams.HandleEventStreamDifferentDataSchemas).Methods(http.MethodPost)
+	r.HandleFunc("/eventstreams/differentdataschemasflatten", eventstreams.HandleEventStreamDifferentDataSchemasFlatten).Methods(http.MethodPost)
 	r.HandleFunc("/clientcredentials/token", clientcredentials.HandleTokenRequest).Methods(http.MethodPost)
 	r.HandleFunc("/clientcredentials/authenticatedrequest", clientcredentials.HandleAuthenticatedRequest).Methods(http.MethodPost)
 	r.HandleFunc("/clientcredentials/alt/token", clientcredentials.HandleTokenRequest).Methods(http.MethodPost)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -75,6 +75,7 @@ func main() {
 	r.HandleFunc("/method/post", method.HandlePost).Methods(http.MethodPost)
 	r.HandleFunc("/method/put", method.HandlePut).Methods(http.MethodPut)
 	r.HandleFunc("/method/trace", method.HandleTrace).Methods(http.MethodTrace)
+
 	oauth2router := r.NewRoute().Subrouter()
 	oauth2router.Use(middleware.OAuth2)
 	oauth2router.HandleFunc("/ecommerce/products", ecommerce.HandleListProducts).Methods(http.MethodGet)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -58,9 +58,10 @@ func main() {
 	r.HandleFunc("/eventstreams/multiline", eventstreams.HandleEventStreamMultiLine).Methods(http.MethodPost)
 	r.HandleFunc("/eventstreams/rich", eventstreams.HandleEventStreamRich).Methods(http.MethodPost)
 	r.HandleFunc("/eventstreams/chat", eventstreams.HandleEventStreamChat).Methods(http.MethodPost)
+	r.HandleFunc("/eventstreams/chat-flat", eventstreams.HandleEventStreamChatFlatten).Methods(http.MethodPost)
 	r.HandleFunc("/eventstreams/chat-chunked", eventstreams.HandleEventStreamChat).Methods(http.MethodPost)
 	r.HandleFunc("/eventstreams/differentdataschemas", eventstreams.HandleEventStreamDifferentDataSchemas).Methods(http.MethodPost)
-	r.HandleFunc("/eventstreams/differentdataschemasflatten", eventstreams.HandleEventStreamDifferentDataSchemasFlatten).Methods(http.MethodPost)
+	r.HandleFunc("/eventstreams/differentdataschemas-flat", eventstreams.HandleEventStreamDifferentDataSchemasFlatten).Methods(http.MethodPost)
 	r.HandleFunc("/clientcredentials/token", clientcredentials.HandleTokenRequest).Methods(http.MethodPost)
 	r.HandleFunc("/clientcredentials/authenticatedrequest", clientcredentials.HandleAuthenticatedRequest).Methods(http.MethodPost)
 	r.HandleFunc("/clientcredentials/alt/token", clientcredentials.HandleTokenRequest).Methods(http.MethodPost)
@@ -74,7 +75,7 @@ func main() {
 	r.HandleFunc("/method/post", method.HandlePost).Methods(http.MethodPost)
 	r.HandleFunc("/method/put", method.HandlePut).Methods(http.MethodPut)
 	r.HandleFunc("/method/trace", method.HandleTrace).Methods(http.MethodTrace)
-
+	
 	oauth2router := r.NewRoute().Subrouter()
 	oauth2router.Use(middleware.OAuth2)
 	oauth2router.HandleFunc("/ecommerce/products", ecommerce.HandleListProducts).Methods(http.MethodGet)

--- a/internal/eventstreams/service.go
+++ b/internal/eventstreams/service.go
@@ -139,6 +139,32 @@ func HandleEventStreamChat(rw http.ResponseWriter, _ *http.Request) {
 	})
 }
 
+func HandleEventStreamChatFlatten(rw http.ResponseWriter, _ *http.Request) {
+	rw.Header().Add("Content-Type", "text/event-stream")
+
+	pushEvents(rw, [][]string{
+		{
+			`data: {"content": "Hello"}`,
+		},
+
+		{
+			`data: {"content": " "}`,
+		},
+
+		{
+			`data: {"content": "world"}`,
+		},
+
+		{
+			`data: {"content": "!"}`,
+		},
+
+		{
+			`data: [DONE]`,
+		},
+	})
+}
+
 func HandleEventStreamChatChunked(rw http.ResponseWriter, _ *http.Request) {
 	rw.Header().Add("Content-Type", "text/event-stream")
 

--- a/internal/eventstreams/service.go
+++ b/internal/eventstreams/service.go
@@ -174,3 +174,27 @@ func HandleEventStreamDifferentDataSchemas(rw http.ResponseWriter, _ *http.Reque
 		},
 	})
 }
+
+func HandleEventStreamDifferentDataSchemasFlatten(rw http.ResponseWriter, _ *http.Request) {
+	rw.Header().Add("Content-Type", "text/event-stream")
+
+	pushEvents(rw, [][]string{
+		{
+			`id: event-1`,
+			`event: message`,
+			`data: {"content": "Here is your url"}`,
+		},
+
+		{
+			`id: event-2`,
+			`event: url`,
+			`data: {"url": "https://example.com"}`,
+		},
+
+		{
+			`id: event-3`,
+			`event: message`,
+			`data: {"content": "Have a great day!"}`,
+		},
+	})
+}


### PR DESCRIPTION
This change adds two endpoints that are intended to "flattened" by the client so data is hoisted upwards. It should also be compatible with arbitrary data streams so one endpoint tests that behavior. The other endpoint tests different data schemas. 