### PR TITLE
chore: update ecommerce updateProductStock scopes + quantity

### DIFF
--- a/internal/ecommerce/service.go
+++ b/internal/ecommerce/service.go
@@ -3,7 +3,6 @@ package ecommerce
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 	"net/http"
 	"strconv"
 	"time"
@@ -205,7 +204,7 @@ func HandleUpdateProductStock(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 
 	scopes, scopesFound := middleware.OAuth2Scopes(r)
-	if !scopesFound || !scopes.Has([]string{"admin"}) {
+	if !scopesFound || !scopes.HasOneOf([]string{"admin", "producs:udpate"}) {
 		http.Error(rw, `{"error": "insufficient scopes"}`, http.StatusForbidden)
 		return
 	}
@@ -235,13 +234,10 @@ func HandleUpdateProductStock(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Seed cannot be 0 otherwise faker picks a random one
-	faker := gofakeit.New(productID + 1)
-
 	now := time.Now().Truncate(24 * time.Second)
 	if err := enc.Encode(ProductInventoryStatus{
 		ProductID: rawID,
-		Quantity:  faker.IntRange(int(math.Abs(float64(form.QuantityDelta))), 100) + form.QuantityDelta,
+		Quantity:  int(10*productID) + form.QuantityDelta,
 		UpdatedAt: now,
 	}); err != nil {
 		http.Error(rw, `{"error": "could not encode response"}`, http.StatusInternalServerError)

--- a/internal/middleware/oauth2.go
+++ b/internal/middleware/oauth2.go
@@ -87,3 +87,13 @@ func (s Scopes) Has(requiredScopes []string) bool {
 
 	return true
 }
+
+func (s Scopes) HasOneOf(allowedScopes []string) bool {
+	for _, scope := range allowedScopes {
+		if slices.Contains(s, scope) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
the [updateProductStock endpoint](https://github.com/speakeasy-api/openapi-generation/blob/main/tests/specs/ecommerce.yaml#L98) in `ecommerce.yaml` is not yet used for testing `oauth2-password` authentication:
- [typescriptV2](https://github.com/speakeasy-api/openapi-generation/blob/main/templates/templates/typescriptv2/tests/oauth2-password/auth_additional.test.ts)
- [javaV2](https://github.com/speakeasy-api/openapi-generation/blob/main/templates/templates/javav2/tests/oauth2-password/AuthAdditionalTest.java#) 

The motivation behind this change is to allow testing with `oauth2:password` as a security option alongside other schemes, e.g.:
```
  - target: $.paths.*.*[?(@.operationId == 'updateProductStock')]
    update:
      security:
        - oauth2Inventory: [admin]
        - oauth2: [products:udpate]
```
