### PR TITLE
feat: Support connection reset fault injection

### DIFF
--- a/internal/middleware/reset_injector.go
+++ b/internal/middleware/reset_injector.go
@@ -7,17 +7,13 @@ import (
 	"github.com/lingrino/go-fault"
 )
 
-var _ fault.Injector = (*ConnectionErrorInjector)(nil)
+var _ fault.Injector = (*ConnectionResetInjector)(nil)
 
-// Injects a connection error by closing the connection immediately.
-// This simulates a connection reset or close error.
-type ConnectionErrorInjector struct {
-	// Enable to set SO_LINGER to 0 before closing, which will cause a TCP RST
-	// packet on most platforms when closing.
-	Reset bool
-}
+// Injects a connection error by closing the connection immediately while also
+// simulating a TCP RST via setting SO_LINGER to 0.
+type ConnectionResetInjector struct{}
 
-func (i *ConnectionErrorInjector) Handler(_ http.Handler) http.Handler {
+func (i *ConnectionResetInjector) Handler(_ http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hijacker, ok := w.(http.Hijacker)
 
@@ -33,7 +29,7 @@ func (i *ConnectionErrorInjector) Handler(_ http.Handler) http.Handler {
 			return
 		}
 
-		if tcpConn, ok := conn.(*net.TCPConn); ok && i.Reset {
+		if tcpConn, ok := conn.(*net.TCPConn); ok {
 			_ = tcpConn.SetLinger(0) // Best effort RST on close
 		}
 


### PR DESCRIPTION
This change supports new `reset_count` fault injection via the `fault-settings` header, which enables connection error testing such as the `x-speakeasy-retries` extension `retryConnectionErrors` configuration. Enabling this injection will immediately close the connection before writing any response (similar to the `reject_count` injection) and sets SO_LINGER to 0, which on most platforms should cause a TCP RST packet.