### PR TITLE
fix: bearer token endpoint

### DIFF
--- a/internal/clientcredentials/service.go
+++ b/internal/clientcredentials/service.go
@@ -87,6 +87,11 @@ func HandleTokenRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	tokenType := r.URL.Query().Get("token_type")
+	if tokenType == "" {
+		tokenType = "Bearer" // default
+	}
+
 	accessToken := firstAccessToken
 
 	_, ok := state.Load(clientSecret)
@@ -106,7 +111,7 @@ func HandleTokenRequest(w http.ResponseWriter, r *http.Request) {
 
 	response := tokenResponse{
 		AccessToken: accessToken,
-		TokenType:   "Bearer",
+		TokenType:   tokenType,
 		ExpiresIn:   0,
 	}
 


### PR DESCRIPTION
**Summary**

  Fix bearer token case sensitivity issue by making token type configurable.

  The change was implemented to test a solution for the following ticket: https://linear.app/speakeasy/issue/GEN-1753/bug-fix-bearer-token-case-sensitivity-issue


**Changes**

  - Add support for configurable token type via token_type query parameter in /oauth/token endpoint
  - Default to "Bearer" when no token type is specified to maintain backward compatibility
  - Replace hardcoded "Bearer" token type with configurable value in token response

**Technical Details**

  The changes are in internal/clientcredentials/service.go:90-94 and internal/clientcredentials/service.go:114 where we now:
  1. Extract token_type from query parameters
  2. Use "Bearer" as default if not provided
  3. Return the specified token type in the OAuth response

This allows clients to specify different token type cases (e.g., "bearer", "Bearer", "BEARER") while maintaining the current behavior as default.