### PR TITLE
feat: add OAuth2 Password endpoint requiring two scopes

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -92,6 +92,7 @@ func main() {
 	oauth2router.HandleFunc("/ecommerce/products", ecommerce.HandleListProducts).Methods(http.MethodGet)
 	oauth2router.HandleFunc("/ecommerce/products", ecommerce.HandleCreateProduct).Methods(http.MethodPost)
 	oauth2router.HandleFunc("/ecommerce/products/{id}", ecommerce.HandleFetchProduct).Methods(http.MethodGet)
+	oauth2router.HandleFunc("/ecommerce/products/{id}", ecommerce.HandleUpdateProduct).Methods(http.MethodPut)
 	oauth2router.HandleFunc("/ecommerce/products/{id}", ecommerce.HandleDeleteProduct).Methods(http.MethodDelete)
 	oauth2router.HandleFunc("/ecommerce/products/{id}/inventory", ecommerce.HandleUpdateProductStock).Methods(http.MethodPut)
 

--- a/internal/clientcredentials/service.go
+++ b/internal/clientcredentials/service.go
@@ -109,7 +109,7 @@ func HandleTokenRequest(w http.ResponseWriter, r *http.Request) {
 	response := tokenResponse{
 		AccessToken: accessToken,
 		TokenType:   tokenType,
-		ExpiresIn:   0,
+		ExpiresIn:   120,
 	}
 
 	if err := json.NewEncoder(w).Encode(response); err != nil {

--- a/internal/clientcredentials/service.go
+++ b/internal/clientcredentials/service.go
@@ -38,7 +38,6 @@ func handleBasicAuth(authHeader string) (clientID, clientSecret string, ok bool)
 	return creds[0], creds[1], true
 }
 
-
 func HandleTokenRequest(w http.ResponseWriter, r *http.Request) {
 	var clientID, clientSecret string
 	err := r.ParseForm()
@@ -64,8 +63,6 @@ func HandleTokenRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid_grant", http.StatusBadRequest)
 		return
 	}
-
-
 
 	if clientID == "" || clientSecret == "" {
 		http.Error(w, "invalid_request", http.StatusBadRequest)

--- a/internal/ecommerce/models.go
+++ b/internal/ecommerce/models.go
@@ -22,10 +22,10 @@ type NewProductForm struct {
 	Price       float64 `json:"price"`
 }
 
-type ProductForm struct {
-	Name        string  `json:"name"`
-	Description string  `json:"description"`
-	Price       float64 `json:"price"`
+type ProductUpdateForm struct {
+	Name        *string  `json:"name"`
+	Description *string  `json:"description"`
+	Price       *float64 `json:"price"`
 }
 
 type ProductInventoryUpdateForm struct {

--- a/internal/ecommerce/service.go
+++ b/internal/ecommerce/service.go
@@ -177,6 +177,75 @@ func HandleFetchProduct(rw http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func HandleUpdateProduct(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+
+	scopes, scopesFound := middleware.OAuth2Scopes(r)
+	if !scopesFound || !scopes.Has([]string{"products:read", "products:create"}) {
+		http.Error(rw, `{"error": "insufficient scopes"}`, http.StatusForbidden)
+		return
+	}
+
+	enc := json.NewEncoder(rw)
+	enc.SetIndent("", "  ")
+
+	vars := mux.Vars(r)
+	rawID, ok := vars["id"]
+	if !ok {
+		http.Error(rw, `{"error": "{id} is required"}`, http.StatusBadRequest)
+		return
+	}
+
+	productID, err := strconv.ParseUint(rawID, 10, 64)
+	if err != nil {
+		http.Error(rw, `{"error": "{id} must a uint64"}`, http.StatusBadRequest)
+		return
+	}
+
+	var form ProductUpdateForm
+	err = json.NewDecoder(r.Body).Decode(&form)
+	if err != nil {
+		http.Error(rw, `{"error": "could not decode request"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Seed cannot be 0 otherwise faker picks a random one
+	faker := gofakeit.New(productID + 1)
+	p := faker.Product()
+	created := faker.DateRange(
+		time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+	).Truncate(24 * time.Hour)
+	updated := faker.DateRange(
+		created,
+		time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+	).Truncate(24 * time.Hour)
+
+	name := p.Name
+	if form.Name != nil {
+		name = *form.Name
+	}
+	description := p.Description
+	if form.Description != nil {
+		description = *form.Description
+	}
+	price := p.Price
+	if form.Price != nil {
+		price = *form.Price
+	}
+
+	if err := enc.Encode(Product{
+		ID:          rawID,
+		Name:        name,
+		Price:       price,
+		Description: description,
+		CreatedAt:   created,
+		UpdatedAt:   updated,
+	}); err != nil {
+		http.Error(rw, `{"error": "could not encode response"}`, http.StatusInternalServerError)
+	}
+}
+
 func HandleDeleteProduct(rw http.ResponseWriter, r *http.Request) {
 	scopes, scopesFound := middleware.OAuth2Scopes(r)
 	if !scopesFound || !scopes.Has([]string{"products:delete"}) {


### PR DESCRIPTION
GEN-1751

1. This PR adds an endpoint that requires both `products:read` and `products:create` scopes to be requested. This will help test the following scenario in https://github.com/speakeasy-api/openapi-generation/pull/3161 :
- create a product -> request a token with scope `products:create`
- update a product -> request a token with both `products:create` and `products:read`
- list products -> only `products:read` is required so reuse the last token received

2. Set the  `ExpireIn` to 2min for the token returned by the  `/clientcredentials/token` endpoint so that we can test reusing a valid token when required scopes have already been requested