### PR TITLE
chore: revert ExpiresIn config

### DIFF
--- a/internal/clientcredentials/service.go
+++ b/internal/clientcredentials/service.go
@@ -109,7 +109,7 @@ func HandleTokenRequest(w http.ResponseWriter, r *http.Request) {
 	response := tokenResponse{
 		AccessToken: accessToken,
 		TokenType:   tokenType,
-		ExpiresIn:   120,
+		ExpiresIn:   0,
 	}
 
 	if err := json.NewEncoder(w).Encode(response); err != nil {


### PR DESCRIPTION
PHP ClientCredentials Hook needs to be fixed before the `ExpiresIn` config can be set

https://github.com/speakeasy-api/openapi-generation/actions/runs/17678988242/job/50248262919#step:7:716